### PR TITLE
Implement Factory pattern, split API

### DIFF
--- a/JavaScript/1-channels.js
+++ b/JavaScript/1-channels.js
@@ -11,32 +11,40 @@ class QueueFactory {
     this.onFailure = null;
     this.onDrain = null;
   }
+
   static init() {
     return new QueueFactory();
   }
+
   build() {
     return new Queue(this);
   }
+
   channels(concurrency) {
     this.concurrency = concurrency;
     return this;
   }
+
   process(listener) {
     this.onProcess = listener;
     return this;
   }
+
   done(listener) {
     this.onDone = listener;
     return this;
   }
+
   success(listener) {
     this.onSuccess = listener;
     return this;
   }
+
   failure(listener) {
     this.onFailure = listener;
     return this;
   }
+
   drain(listener) {
     this.onDrain = listener;
     return this;
@@ -47,16 +55,20 @@ class Queue {
   constructor(factoryContext) {
     this.count = 0;
     this.waiting = [];
+
     Object.assign(this, factoryContext);    
   }
+
   add(task) {
     const hasChannel = this.count < this.concurrency;
+
     if (hasChannel) {
       this.next(task);
       return;
     }
     this.waiting.push(task);
   }
+
   next(task) {
     this.count++;
     this.onProcess(task, (err, result) => {
@@ -66,9 +78,11 @@ class Queue {
         this.onSuccess(result);
       }
       if (this.onDone) this.onDone(err, result);
+
       this.count--;
       if (this.waiting.length > 0) {
         const task = this.waiting.shift();
+
         this.next(task);
         return;
       }
@@ -102,3 +116,4 @@ const queue = QueueFactory.init()
 for (let i = 0; i < 10; i++) {
   queue.add({ name: `Task${i}`, interval: i * 1000 });
 }
+

--- a/JavaScript/2-timeouts.js
+++ b/JavaScript/2-timeouts.js
@@ -13,40 +13,50 @@ class QueueFactory {
     this.onFailure = null;
     this.onDrain = null;
   }
+
   static init() {
     return new QueueFactory();
   }
+
   build() {
     return new Queue(this);
   }
+
   wait(msec) {
     this.waitTimeout = msec;
     return this;
   }
+
   timeout(msec) {
     this.processTimeout = msec;
     return this;
   }
+
   channels(concurrency) {
     this.concurrency = concurrency;
     return this;
   }
+
   process(listener) {
     this.onProcess = listener;
     return this;
   }
+
   done(listener) {
     this.onDone = listener;
     return this;
   }
+
   success(listener) {
     this.onSuccess = listener;
     return this;
   }
+
   failure(listener) {
     this.onFailure = listener;
     return this;
   }
+
   drain(listener) {
     this.onDrain = listener;
     return this;
@@ -57,16 +67,20 @@ class Queue {
   constructor(factoryContext) {
     this.count = 0;
     this.waiting = [];
+
     Object.assign(this, factoryContext);   
   }
+
   add(task) {
     const hasChannel = this.count < this.concurrency;
+
     if (hasChannel) {
       this.next(task);
       return;
     }
     this.waiting.push({ task, start: Date.now() });
   }
+
   next(task) {
     this.count++;
     let timer = null;
@@ -80,6 +94,7 @@ class Queue {
       this.finish(err, res);
       if (this.waiting.length > 0) this.takeNext();
     };
+
     if (processTimeout !== Infinity) {
       timer = setTimeout(() => {
         timer = null;
@@ -89,9 +104,11 @@ class Queue {
     }
     onProcess(task, finish);
   }
+
   takeNext() {
     const { waiting, waitTimeout } = this;
     const { task, start } = waiting.shift();
+
     if (waitTimeout !== Infinity) {
       const delay = Date.now() - start;
       if (delay > waitTimeout) {
@@ -104,6 +121,7 @@ class Queue {
     this.next(task);
     return;
   }
+
   finish(err, res) {
     const { onFailure, onSuccess, onDone, onDrain } = this;
     if (err) {
@@ -135,3 +153,4 @@ const queue = QueueFactory.init()
 for (let i = 0; i < 10; i++) {
   queue.add({ name: `Task${i}`, interval: i * 1000 });
 }
+

--- a/JavaScript/2-timeouts.js
+++ b/JavaScript/2-timeouts.js
@@ -1,20 +1,23 @@
 'use strict';
 
-class Queue {
-  constructor(concurrency) {
-    this.concurrency = concurrency;
+class QueueFactory {
+  constructor() {
+    this.concurrency = 0;
     this.count = 0;
     this.waiting = [];
+    this.waitTimeout = Infinity;
+    this.processTimeout = Infinity;
     this.onProcess = null;
     this.onDone = null;
     this.onSuccess = null;
     this.onFailure = null;
     this.onDrain = null;
-    this.waitTimeout = Infinity;
-    this.processTimeout = Infinity;
   }
-  static channels(concurrency) {
-    return new Queue(concurrency);
+  static init() {
+    return new QueueFactory();
+  }
+  build() {
+    return new Queue(this);
   }
   wait(msec) {
     this.waitTimeout = msec;
@@ -23,6 +26,38 @@ class Queue {
   timeout(msec) {
     this.processTimeout = msec;
     return this;
+  }
+  channels(concurrency) {
+    this.concurrency = concurrency;
+    return this;
+  }
+  process(listener) {
+    this.onProcess = listener;
+    return this;
+  }
+  done(listener) {
+    this.onDone = listener;
+    return this;
+  }
+  success(listener) {
+    this.onSuccess = listener;
+    return this;
+  }
+  failure(listener) {
+    this.onFailure = listener;
+    return this;
+  }
+  drain(listener) {
+    this.onDrain = listener;
+    return this;
+  }
+}
+
+class Queue {
+  constructor(factoryContext) {
+    this.count = 0;
+    this.waiting = [];
+    Object.assign(this, factoryContext);   
   }
   add(task) {
     const hasChannel = this.count < this.concurrency;
@@ -79,26 +114,6 @@ class Queue {
     if (onDone) onDone(err, res);
     if (this.count === 0 && onDrain) onDrain();
   }
-  process(listener) {
-    this.onProcess = listener;
-    return this;
-  }
-  done(listener) {
-    this.onDone = listener;
-    return this;
-  }
-  success(listener) {
-    this.onSuccess = listener;
-    return this;
-  }
-  failure(listener) {
-    this.onFailure = listener;
-    return this;
-  }
-  drain(listener) {
-    this.onDrain = listener;
-    return this;
-  }
 }
 
 // Usage
@@ -107,13 +122,15 @@ const job = (task, next) => {
   setTimeout(next, task.interval, null, task);
 };
 
-const queue = Queue.channels(3)
+const queue = QueueFactory.init()
+  .channels(3)
   .wait(4000)
   .timeout(5000)
   .process(job)
   .success(task => console.log(`Success: ${task.name}`))
   .failure((err, task) => console.log(`Failure: ${err} ${task.name}`))
-  .drain(() => console.log('Queue drain'));
+  .drain(() => console.log('Queue drain'))
+  .build();
 
 for (let i = 0; i < 10; i++) {
   queue.add({ name: `Task${i}`, interval: i * 1000 });

--- a/JavaScript/3-pause.js
+++ b/JavaScript/3-pause.js
@@ -124,14 +124,13 @@ class Queue {
     return this;
   }
   resume() {
-    this.paused = false;
     if (this.waiting.length > 0) {
       const channels = this.concurrency - this.count;
       for (let i = 0; i < channels; i++) {
         this.takeNext();
       }
-      this.paused = false;
     }
+    this.paused = false;
     return this;
   }
 }

--- a/JavaScript/3-pause.js
+++ b/JavaScript/3-pause.js
@@ -99,7 +99,7 @@ class Queue {
         this.finish(err, task);
         if (waiting.length > 0) {
           setTimeout(() => {
-            if (!this.paused) this.takeNext();
+            if (!this.paused && waiting.length > 0) this.takeNext();
           }, 0);
         }
         return;
@@ -126,8 +126,11 @@ class Queue {
   resume() {
     this.paused = false;
     if (this.waiting.length > 0) {
-      const hasChannel = this.count < this.concurrency;
-      if (hasChannel) this.takeNext();
+      const channels = this.concurrency - this.count;
+      for (let i = 0; i < channels; i++) {
+        this.takeNext();
+      }
+      this.paused = false;
     }
     return this;
   }

--- a/JavaScript/3-pause.js
+++ b/JavaScript/3-pause.js
@@ -12,41 +12,51 @@ class QueueFactory {
     this.onSuccess = null;
     this.onFailure = null;
     this.onDrain = null;
-  }
+  } 
+
   static init() {
     return new QueueFactory();
   }
+
   build() {
     return new Queue(this);
   }
+
   wait(msec) {
     this.waitTimeout = msec;
     return this;
   }
+
   timeout(msec) {
     this.processTimeout = msec;
     return this;
   }
+
   channels(concurrency) {
     this.concurrency = concurrency;
     return this;
   }
+
   process(listener) {
     this.onProcess = listener;
     return this;
   }
+
   done(listener) {
     this.onDone = listener;
     return this;
   }
+
   success(listener) {
     this.onSuccess = listener;
     return this;
   }
+
   failure(listener) {
     this.onFailure = listener;
     return this;
   }
+
   drain(listener) {
     this.onDrain = listener;
     return this;
@@ -60,6 +70,7 @@ class Queue {
     this.waiting = [];
     Object.assign(this, factoryContext);    
   }
+
   add(task) {
     if (!this.paused) {
       const hasChannel = this.count < this.concurrency;
@@ -70,6 +81,7 @@ class Queue {
     }
     this.waiting.push({ task, start: Date.now() });
   }
+
   next(task) {
     this.count++;
     let timer = null;
@@ -83,15 +95,18 @@ class Queue {
       this.finish(err, res);
       if (!this.paused && this.waiting.length > 0) this.takeNext();
     };
+
     if (processTimeout !== Infinity) {
       const err = new Error('Process timed out');
       timer = setTimeout(finish, processTimeout, err, task);
     }
     onProcess(task, finish);
   }
+
   takeNext() {
     const { waiting, waitTimeout } = this;
     const { task, start } = waiting.shift();
+
     if (waitTimeout !== Infinity) {
       const delay = Date.now() - start;
       if (delay > waitTimeout) {
@@ -105,10 +120,12 @@ class Queue {
         return;
       }
     }
+
     const hasChannel = this.count < this.concurrency;
     if (hasChannel) this.next(task);
     return;
   }
+
   finish(err, res) {
     const { onFailure, onSuccess, onDone, onDrain } = this;
     if (err) {
@@ -119,10 +136,12 @@ class Queue {
     if (onDone) onDone(err, res);
     if (this.count === 0 && onDrain) onDrain();
   }
+
   pause() {
     this.paused = true;
     return this;
   }
+
   resume() {
     if (this.waiting.length > 0) {
       const channels = this.concurrency - this.count;
@@ -171,3 +190,4 @@ setTimeout(() => {
   console.log('Resume');
   queue.resume();
 }, 5000);
+

--- a/JavaScript/4-priority.js
+++ b/JavaScript/4-priority.js
@@ -1,22 +1,28 @@
 'use strict';
 
-class Queue {
-  constructor(concurrency) {
-    this.paused = false;
-    this.concurrency = concurrency;
+class QueueFactory {
+  constructor() {
+    this.concurrency = 0;
     this.count = 0;
     this.waiting = [];
+    this.priorityMode = false;
+    this.waitTimeout = Infinity;
+    this.processTimeout = Infinity;
     this.onProcess = null;
     this.onDone = null;
     this.onSuccess = null;
     this.onFailure = null;
     this.onDrain = null;
-    this.waitTimeout = Infinity;
-    this.processTimeout = Infinity;
-    this.priorityMode = false;
   }
-  static channels(concurrency) {
-    return new Queue(concurrency);
+  static init() {
+    return new QueueFactory();
+  }
+  build() {
+    return new Queue(this);
+  } 
+  priority(flag = true) {
+    this.priorityMode = flag;
+    return this;
   }
   wait(msec) {
     this.waitTimeout = msec;
@@ -25,6 +31,39 @@ class Queue {
   timeout(msec) {
     this.processTimeout = msec;
     return this;
+  }
+  channels(concurrency) {
+    this.concurrency = concurrency;
+    return this;
+  }
+  process(listener) {
+    this.onProcess = listener;
+    return this;
+  }
+  done(listener) {
+    this.onDone = listener;
+    return this;
+  }
+  success(listener) {
+    this.onSuccess = listener;
+    return this;
+  }
+  failure(listener) {
+    this.onFailure = listener;
+    return this;
+  }
+  drain(listener) {
+    this.onDrain = listener;
+    return this;
+  }
+}
+
+class Queue {
+  constructor(factoryContext) {
+    this.paused = false;
+    this.count = 0;
+    this.waiting = [];
+    Object.assign(this, factoryContext);
   }
   add(task, priority = 0) {
     if (!this.paused) {
@@ -88,26 +127,6 @@ class Queue {
     if (onDone) onDone(err, res);
     if (this.count === 0 && onDrain) onDrain();
   }
-  process(listener) {
-    this.onProcess = listener;
-    return this;
-  }
-  done(listener) {
-    this.onDone = listener;
-    return this;
-  }
-  success(listener) {
-    this.onSuccess = listener;
-    return this;
-  }
-  failure(listener) {
-    this.onFailure = listener;
-    return this;
-  }
-  drain(listener) {
-    this.onDrain = listener;
-    return this;
-  }
   pause() {
     this.paused = true;
     return this;
@@ -120,10 +139,6 @@ class Queue {
     }
     return this;
   }
-  priority(flag = true) {
-    this.priorityMode = flag;
-    return this;
-  }
 }
 
 // Usage
@@ -132,11 +147,13 @@ const job = (task, next) => {
   setTimeout(next, task.interval, null, task);
 };
 
-const queue = Queue.channels(3)
+const queue = QueueFactory.init()
+  .channels(3)
   .process(job)
   .priority()
   .done((err, task) => console.log(`Done: ${task.name}`))
-  .drain(() => console.log('Queue drain'));
+  .drain(() => console.log('Queue drain'))
+  .build();
 
 for (let i = 0; i < 10; i++) {
   queue.add({ name: `Task${i}`, interval: 1000 }, i);

--- a/JavaScript/4-priority.js
+++ b/JavaScript/4-priority.js
@@ -107,7 +107,7 @@ class Queue {
         this.finish(err, task);
         if (waiting.length > 0) {
           setTimeout(() => {
-            if (this.paused && waiting.length > 0) this.takeNext();
+            if (!this.paused && waiting.length > 0) this.takeNext();
           }, 0);
         }
         return;
@@ -132,11 +132,13 @@ class Queue {
     return this;
   }
   resume() {
-    this.paused = false;
     if (this.waiting.length > 0) {
-      const hasChannel = this.count < this.concurrency;
-      if (hasChannel) this.takeNext();
+      const channels = this.concurrency - this.count;
+      for (let i = 0; i < channels; i++) {
+        this.takeNext();
+      }
     }
+    this.paused = false;
     return this;
   }
 }

--- a/JavaScript/5-pipe.js
+++ b/JavaScript/5-pipe.js
@@ -109,7 +109,7 @@ class Queue {
         this.finish(err, task);
         if (waiting.length > 0) {
           setTimeout(() => {
-            if (this.paused && waiting.length > 0) this.takeNext();
+            if (!this.paused && waiting.length > 0) this.takeNext();
           }, 0);
         }
         return;
@@ -135,11 +135,13 @@ class Queue {
     return this;
   }
   resume() {
-    this.paused = false;
     if (this.waiting.length > 0) {
-      const hasChannel = this.count < this.concurrency;
-      if (hasChannel) this.takeNext();
+      const channels = this.concurrency - this.count;
+      for (let i = 0; i < channels; i++) {
+        this.takeNext();
+      }
     }
+    this.paused = false;
     return this;
   }
   pipe(destination) {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# ConcurrentQueue
-Asynchronous Concurrent Queue with Priority and Factor
+## Asynchronous Concurrent Queue with Priority and Factor
+
+[![Конкурентная асинхронная очередь на JavaScript](https://img.youtube.com/vi/Lg46AH8wFvg/0.jpg)](https://www.youtube.com/watch?v=Lg46AH8wFvg)


### PR DESCRIPTION
In my opinion leaving a Queue class with access to changing onProcess, onFailure, etc callbacks is not right. So I added a QueueFactory which builds a Queue object with restricted API.